### PR TITLE
KLIMA-38: Add posibility for 5 different font-sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 
 ### Added
 - Ctabox in frontend
+- Frontend config for font size
 - Frontend config for icons and logo
 - Symfony 6.2
 - API Platform 3.1

--- a/assets/react/components/grid-item.jsx
+++ b/assets/react/components/grid-item.jsx
@@ -3,14 +3,16 @@ import styled from 'styled-components'
 import Icon from './icon';
 import PropTypes from "prop-types";
 
-function GridItem({variant, description, image, exposed, tileIcons, tileBorders}) {
+function GridItem({variant, description, image, exposed, tileIcons, tileBorders, exposeFontSize}) {
     return (
         <Wrapper className={exposed ? "exposed" : ""}>
             <Item className={variant} style={{
                 '--background-image': `url(${image}`,
                 '--border-width': tileBorders ? 'var(--tile-border-width)' : 0
             }}>
-                {exposed && <ItemDescription>{description}</ItemDescription>}
+                {exposed && <ItemDescription style={{
+                      '--text-size': `var(--font-size-${exposeFontSize})`
+                  }}>{description}</ItemDescription>}
                 {tileIcons && <ItemIcon src={Icon[variant]} alt=""/>}
             </Item>
         </Wrapper>
@@ -24,11 +26,12 @@ GridItem.propTypes = {
     exposed: PropTypes.bool,
     tileIcons: PropTypes.bool,
     tileBorders: PropTypes.bool,
+    exposeFontSize: PropTypes.string,
 };
 
 const ItemDescription = styled.p`
-  font-size: var(--font-size-h2);
-  font-weight: var(--font-weight-h2);
+  font-size: var(--text-size);
+  font-weight: var(--font-weight-bold);
   line-height: 1.2;
   color: white;
   position: absolute;

--- a/assets/react/controllers/Mosaic.jsx
+++ b/assets/react/controllers/Mosaic.jsx
@@ -181,6 +181,7 @@ function Mosaic() {
                                     exposed
                                     tileIcons={config.variant.exposeShowIcon ?? false}
                                     tileBorders={config.variant.exposeShowBorder ?? false}
+                                    exposeFontSize={config.variant.exposeFontSize}
                                     forwardRef={nodeRefs[exposedTile['@id']]}
                                 />
                             </CSSTransition>

--- a/assets/react/controllers/Mosaic.jsx
+++ b/assets/react/controllers/Mosaic.jsx
@@ -181,7 +181,7 @@ function Mosaic() {
                                     exposed
                                     tileIcons={config.variant.exposeShowIcon ?? false}
                                     tileBorders={config.variant.exposeShowBorder ?? false}
-                                    exposeFontSize={config.variant.exposeFontSize}
+                                    exposeFontSize={config.variant.exposeFontSize ?? 'm'}
                                     forwardRef={nodeRefs[exposedTile['@id']]}
                                 />
                             </CSSTransition>

--- a/assets/react/global-styles.js
+++ b/assets/react/global-styles.js
@@ -92,13 +92,14 @@ const GlobalStyles = createGlobalStyle`
       1.5vw + 1rem,
       2rem
     );
-    --font-size-h2: clamp(
-      1.5rem,
-      4vw + 1rem,
-      4rem
-    );
     --font-weight-normal: 400;
     --font-weight-bold: 700;
+
+    --font-size-xs: calc(var(--font-size-base) * 0.5);
+    --font-size-s: calc(var(--font-size-base) * 0.75);
+    --font-size-m: var(--font-size-base);
+    --font-size-l: calc(var(--font-size-base) * 1.25);
+    --font-size-xl: calc(var(--font-size-base) * 1.5);
 
     /*
       Border


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/KLIMA-38

#### Description

Add configuration option for font size for the text in an exposed Tile. 
The values that can be used in config is exposeFontSize: [xs, s, m, l, xl]

#### Screenshot of the result

![Screenshot 2023-03-28 at 12 25 29](https://user-images.githubusercontent.com/332915/228207768-78a332c6-c87c-4e4b-b1f2-50182a74517a.png)
![Screenshot 2023-03-28 at 12 25 47](https://user-images.githubusercontent.com/332915/228207781-9f26328e-8136-4825-834c-fb83586266ce.png)


#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
