### PR TITLE
KLIMA-51: Fixed that /random should not show not accepted tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 
 ## [Unreleased]
 
+- Fixed that /random should not show not accepted tiles
 - Added monolog and mime packages
 - Fix tiles image path
 

--- a/src/Repository/TileRepository.php
+++ b/src/Repository/TileRepository.php
@@ -52,7 +52,8 @@ class TileRepository extends ServiceEntityRepository
     public function getRandomTiles(int $limit): array
     {
         $queryBuilder = $this->createQueryBuilder('t')
-            ->addSelect('RAND() as HIDDEN rand')->orderBy('rand');
+            ->addSelect('RAND() as HIDDEN rand')->orderBy('rand')
+            ->andWhere('t.accepted = true');
 
         $query = $this->getEntityManager()
             ->createQuery($queryBuilder->getDQL())


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/KLIMA-51

#### Description

Fixed that /random should not show not accepted tiles.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
