### PR TITLE
Fix large images breaking out of footer in chrome.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 
 ## [Unreleased]
 
+- Fix image in footer
 - Add tileTags filter.
 - Add configurable footer
 - Sort tiles last changed first.

--- a/assets/react/components/footer.jsx
+++ b/assets/react/components/footer.jsx
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
 `;
 
 const Img = styled.img`
-  max-height: 100%;
+  max-height: calc((100vh / var(--total-rows)) * var(--footer-height));
   width: auto;
 `;
 


### PR DESCRIPTION
#### Link to ticket

n/a

#### Description

Fix large images breaking out of footer in chrome.

#### Screenshot of the result

n/a

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
