### PR TITLE
Feature/klima 77 dont show unloaded image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 
 ## [Unreleased]
 - Added linting and skeleton component
+- Display none on image until fully loaded, added default skeleton component colors
 
 ## [1.0.0] - 2023-06-29
 

--- a/assets/react/components/grid-item.jsx
+++ b/assets/react/components/grid-item.jsx
@@ -22,9 +22,9 @@ function GridItem({
         {!imageReady && (
           <Skeleton
             style={{
-              "--skeleton-color-1": hexToRgba(color, 0.4),
-              "--skeleton-color-2": hexToRgba(color, 0.7),
-              "--skeleton-color-3": hexToRgba(color, 1),
+              "--skeleton-color-1": hexToRgba(color || "#fff", 0.4),
+              "--skeleton-color-2": hexToRgba(color || "#d3d3d3", 0.7),
+              "--skeleton-color-3": hexToRgba(color || "#c0c0c0", 1),
             }}
           />
         )}
@@ -34,6 +34,7 @@ function GridItem({
             src={image}
             className={variant}
             style={{
+              display: imageReady ? "flex" : "none",
               "--border-width": tileBorders ? "var(--tile-border-width)" : 0,
               "--overlay-opacity": tileBorders ? "0.1" : "0",
             }}

--- a/assets/react/controllers/Mosaic.jsx
+++ b/assets/react/controllers/Mosaic.jsx
@@ -155,10 +155,6 @@ function Mosaic() {
   }, [screen]);
 
   useEffect(() => {
-    console.log(config);
-  }, [config]);
-
-  useEffect(() => {
     if (config === null) {
       return;
     }

--- a/assets/react/controllers/Mosaic.jsx
+++ b/assets/react/controllers/Mosaic.jsx
@@ -10,7 +10,7 @@ import CtaBox from "../components/cta-box";
 import Footer from "../components/footer";
 
 function Mosaic() {
-  const TILES_LOADING_INTERVAL = 5000;
+  const TILES_LOADING_INTERVAL = 60 * 1000 * 5;
 
   const [params, setParams] = useState(null);
   const [screen, setScreen] = useState(null);
@@ -141,7 +141,7 @@ function Mosaic() {
       ? totalRows - variant.footerHeight
       : totalRows ?? 5;
     const numberOfTiles = gridColumns * gridRows;
-    const { loadingScreenColors } = variant;
+    const loadingScreenColors = variant.loadingScreenColors || [];
 
     setConfig({
       gridColumns,
@@ -153,6 +153,10 @@ function Mosaic() {
       loadingScreenColors,
     });
   }, [screen]);
+
+  useEffect(() => {
+    console.log(config);
+  }, [config]);
 
   useEffect(() => {
     if (config === null) {


### PR DESCRIPTION
#### Link to ticket

https://jira.itkdev.dk/browse/KLIMA-77

#### Description

- [Reverted mistake from prev pr](https://github.com/itk-dev/aarhusmosaic/blob/a2642a1ef0c7f9a89242a0ab4f913dc648bf5869/assets/react/controllers/Mosaic.jsx#L13)
- added display none to image until loaded
- added hardcoded backupcolors, variations of white/grey
